### PR TITLE
Upgrade to 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Build 5.2.0 (PENDING)
+- Fixed important bug caused by bad calculated "more work" blockchain
+  - Previous "more work" (introduced on build 1.5.0.0 2017-02-15) was calculated by SUM(compact_target), but compact_target is a linear value (not exponential)
+  - Current "more work" will be equals to "aggregated hashrate" that is SUM(CompactTargetToHashRate(compact_target)) where "hashrate" is exponential
+  - This important bug was found by Herman Schoenfeld (herman@sphere10.com)
+- NAT limited to 7 seconds by default as proposed by Herman Schoenfeld (herman@sphere10.com) in order to minimize a warp timestamp attack. This value can be configured.
+- Fix invalid "balance" rounded decimals value caused by FPC (daemon or Linux versions)
+- Improvements on hashlib4pascal library by Ugochukwu Mmaduekwe <https://github.com/Xor-el>
+- Minor improvements and fixed bugs
+
 ## Build 5.1.0 - 2019-11-25
 - Fixed FastPropagation bug when Operations are not on Mempool and needs to obtain from a node with different version (V4 vs V5)
 - Fixed TOpChangeAccountInfo bug when changing Account.Data (not available on V4, V5 must not propagate while on V4 protocol)

--- a/src/core/UAccounts.pas
+++ b/src/core/UAccounts.pas
@@ -1547,8 +1547,11 @@ begin
 end;
 
 class function TAccountComp.FormatMoneyDecimal(Money : Int64) : Currency;
+var Ltmp : Double;
 begin
-  Result := RoundTo( Money / 10000.0, -4);
+  Ltmp := Money;
+  Ltmp := Ltmp / 10000.0;
+  Result := RoundTo( Ltmp , -4);
 end;
 
 class function TAccountComp.GetECInfoTxt(const EC_OpenSSL_NID: Word): String;

--- a/src/core/UAccounts.pas
+++ b/src/core/UAccounts.pas
@@ -289,6 +289,7 @@ Type
     FSafeBoxHash : TRawBytes;
     FLock: TPCCriticalSection; // Thread safe
     FWorkSum : UInt64;
+    FAggregatedHashrate : TBigNum;
     FCurrentProtocol: Integer;
     // Snapshots utility new on V3
     FSnapshots : TList<Pointer>; // Will save a Snapshots lists in order to rollback Safebox to a previous block state
@@ -372,6 +373,9 @@ Type
     Function HasSnapshotForBlock(block_number : Cardinal) : Boolean;
     Property OrderedAccountKeysList : TOrderedAccountKeysList read FOrderedAccountKeysList;
     property BufferBlocksHash: TBytesBuffer32Safebox read FBufferBlocksHash; // Warning: For testing purposes, do not use this property! TODO delete or put in protected mode
+
+    Property AggregatedHashrate : TBigNum read FAggregatedHashrate;
+    procedure GetAggregatedHashrateOnBlock(ABlockNumber : Cardinal; const AAggregatedHashrate : TBigNum);
   End;
 
 
@@ -2219,12 +2223,13 @@ Type
     oldTotalFee: Int64;
     oldSafeBoxHash : TRawBytes;
     oldWorkSum : UInt64;
+    oldAggregatedHashrate : TBigNum;
     oldCurrentProtocol: Integer;
   end;
   PSafeboxSnapshot = ^TSafeboxSnapshot;
 
 Const
-  CT_TSafeboxSnapshot_NUL : TSafeboxSnapshot = (nBlockNumber : 0; oldBlocks : Nil; newBlocks : Nil; namesDeleted : Nil; namesAdded : Nil;oldBufferBlocksHash:Nil;oldTotalBalance:0;oldTotalFee:0;oldSafeBoxHash:Nil;oldWorkSum:0;oldCurrentProtocol:0);
+  CT_TSafeboxSnapshot_NUL : TSafeboxSnapshot = (nBlockNumber : 0; oldBlocks : Nil; newBlocks : Nil; namesDeleted : Nil; namesAdded : Nil;oldBufferBlocksHash:Nil;oldTotalBalance:0;oldTotalFee:0;oldSafeBoxHash:Nil;oldWorkSum:0;oldAggregatedHashrate:Nil;oldCurrentProtocol:0);
 
 function TPCSafeBox.Account(account_number: Cardinal): TAccount;
 var
@@ -2280,6 +2285,7 @@ var i, base_addr : Integer;
   //
   acc_0_miner_reward,acc_4_dev_reward : Int64;
   acc_4_for_dev : Boolean;
+  LBlockHashRate : TBigNum;
 begin
   Result := CT_BlockAccount_NUL;
   Result.blockchainInfo := blockChain;
@@ -2328,6 +2334,13 @@ begin
   end;
   Inc(FWorkSum,Result.blockchainInfo.compact_target);
   Result.AccumulatedWork := FWorkSum;
+  // Add Aggregated Work based on HashRate
+  LBlockHashRate := TBigNum.TargetToHashRate( blockChain.compact_target );
+  Try
+    FAggregatedHashrate.Add( LBlockHashRate );
+  finally
+    LBlockHashRate.Free;
+  end;
   // Calc block hash
   Result.block_hash := CalcBlockHash(Result,FCurrentProtocol);
   If Assigned(FPreviousSafeBox) then begin
@@ -2363,6 +2376,7 @@ begin
     Psnapshot^.oldTotalFee:=FTotalFee;
     Psnapshot^.oldSafeBoxHash := FSafeBoxHash;
     Psnapshot^.oldWorkSum := FWorkSum;
+    Psnapshot^.oldAggregatedHashrate := FAggregatedHashrate.Copy;
     Psnapshot^.oldCurrentProtocol:= FCurrentProtocol;
     FSnapshots.Add(Psnapshot);
     FModifiedBlocksPreviousState := TOrderedBlockAccountList.Create;
@@ -2381,6 +2395,7 @@ begin
         FreeAndNil( Psnapshot^.namesAdded );
         FreeAndNil( Psnapshot^.namesDeleted );
         FreeAndNil( Psnapshot^.oldBufferBlocksHash );
+        FreeAndNil( Psnapshot^.oldAggregatedHashrate );
         Psnapshot^.oldSafeBoxHash := Nil;
         Dispose(Psnapshot);
       end;
@@ -2678,6 +2693,7 @@ begin
       FreeAndNil(Psnapshot^.namesAdded);
       FreeAndNil(Psnapshot^.namesDeleted);
       FreeAndNil(Psnapshot^.oldBufferBlocksHash);
+      FreeAndNil(Psnapshot^.oldAggregatedHashrate);
       Psnapshot^.oldSafeBoxHash := Nil;
       Dispose(Psnapshot);
     end;
@@ -2692,6 +2708,7 @@ begin
     FTotalFee := 0;
     FSafeBoxHash := CalcSafeBoxHash;
     FWorkSum := 0;
+    FAggregatedHashrate.Value := 0;
     FCurrentProtocol := CT_PROTOCOL_1;
     FModifiedBlocksSeparatedChain.Clear;
     FModifiedBlocksFinalState.Clear;
@@ -2747,6 +2764,7 @@ begin
       FBufferBlocksHash.CopyFrom(accounts.FBufferBlocksHash);
       FSafeBoxHash := Copy(accounts.FSafeBoxHash);
       FWorkSum := accounts.FWorkSum;
+      FAggregatedHashrate.RawValue := accounts.FAggregatedHashrate.RawValue;
       FCurrentProtocol := accounts.FCurrentProtocol;
     finally
       accounts.EndThreadSave;
@@ -2758,6 +2776,7 @@ end;
 
 constructor TPCSafeBox.Create;
 begin
+  FAggregatedHashrate := TBigNum.Create(0);
   FMaxSafeboxSnapshots:=CT_DEFAULT_MaxSafeboxSnapshots;
   FLock := TPCCriticalSection.Create('TPCSafeBox_Lock');
   FBlockAccountsList := TList<Pointer>.Create;
@@ -2804,6 +2823,7 @@ begin
     FPreviousSafeboxOriginBlock:=-1;
   end;
   FreeAndNil(FBufferBlocksHash);
+  FreeAndNil(FAggregatedHashrate);
   inherited;
 end;
 
@@ -2840,6 +2860,7 @@ begin
         FTotalFee := Psnapshot^.oldTotalFee;
         FSafeBoxHash := Psnapshot^.oldSafeBoxHash;
         FWorkSum := Psnapshot^.oldWorkSum;
+        FAggregatedHashrate.RawValue := Psnapshot^.oldAggregatedHashrate.RawValue;
         FCurrentProtocol := Psnapshot^.oldCurrentProtocol;
       finally
         APreviousSafeBox.EndThreadSave;
@@ -2963,6 +2984,9 @@ begin
       end;
       If (FPreviousSafeBox.WorkSum<>FWorkSum) then begin
         errors := errors+'> Invalid WorkSum!';
+      end;
+      If (FPreviousSafeBox.FAggregatedHashrate.CompareTo(FAggregatedHashrate)<>0) then begin
+        errors := errors+'> Invalid Aggregated Hashrate!';
       end;
       If (FPreviousSafeBox.FCurrentProtocol<>FCurrentProtocol) then begin
         errors := errors+'> Invalid Protocol!';
@@ -3095,6 +3119,7 @@ begin
       Psnapshot^.namesAdded.Free;
       Psnapshot^.namesDeleted.Free;
       Psnapshot^.oldBufferBlocksHash.Free;
+      Psnapshot^.oldAggregatedHashrate.Free;
       Psnapshot^.oldSafeBoxHash := Nil;
       Dispose(Psnapshot);
     end;
@@ -3109,6 +3134,7 @@ begin
     FTotalFee := Psnapshot^.oldTotalFee;
     FSafeBoxHash := Psnapshot^.oldSafeBoxHash;
     FWorkSum := Psnapshot^.oldWorkSum;
+    FAggregatedHashrate.RawValue := Psnapshot^.oldAggregatedHashrate.RawValue;
     FCurrentProtocol := Psnapshot^.oldCurrentProtocol;
     // Clear data
     FAddedNamesSincePreviousSafebox.Clear;
@@ -3220,6 +3246,7 @@ Var
   LUseMultiThreadOperationsBlockValidator, LAddToMultiThreadOperationsBlockValidator : Boolean;
   LPCOperationsBlockValidator : TPCOperationsBlockValidator;
   LValidatedOPOk, LValidatedOPError, LValidatedOPPending : Integer;
+  LBlockHashRate : TBigNum;
 begin
   LPCOperationsBlockValidator := Nil;
   if checkAll then begin
@@ -3413,6 +3440,12 @@ begin
         FBufferBlocksHash.Replace( j, P^.block_hash[0], 32 );
         ALastReadBlock := LBlock;
         Inc(FWorkSum,LBlock.blockchainInfo.compact_target);
+        LBlockHashRate := TBigNum.TargetToHashRate( LBlock.blockchainInfo.compact_target );
+        Try
+          FAggregatedHashrate.Add( LBlockHashRate );
+        finally
+          LBlockHashRate.Free;
+        end;
         // Upgrade to Protocol 4,5... step:
         if (LBlock.blockchainInfo.protocol_version>FCurrentProtocol) then begin
           if (LBlock.blockchainInfo.protocol_version = CT_PROTOCOL_4) then begin
@@ -4149,6 +4182,38 @@ begin
       Raise Exception.Create('ERROR DEV 20180306-1 Protocol not valid');
     end;
   end;
+end;
+
+procedure TPCSafeBox.GetAggregatedHashrateOnBlock(ABlockNumber: Cardinal; const AAggregatedHashrate: TBigNum);
+var i : Integer;
+  LHashRate : TBigNum;
+begin
+  AAggregatedHashrate.Value := 0; // Set to zero
+  if ABlockNumber>=BlocksCount then raise Exception.Create(Format('BlockNumber %d out of range (%d / %d)',[ABlockNumber,0,BlocksCount]));
+
+  if (BlocksCount DIV 2) < ABlockNumber then begin
+    // decrease mode
+    AAggregatedHashrate.RawValue := FAggregatedHashrate.RawValue;
+    for i := Integer(BlocksCount)-1 downto (ABlockNumber+1) do begin
+      LHashRate := TBigNum.TargetToHashRate( GetBlockInfo(i).compact_target );
+      try
+        AAggregatedHashrate.Sub( LHashRate );
+      finally
+        LHashRate.Free;
+      end;
+    end;
+  end else begin
+    // Increase mode
+    for i := 0 to ABlockNumber do begin
+      LHashRate := TBigNum.TargetToHashRate( GetBlockInfo(i).compact_target );
+      try
+        AAggregatedHashrate.Add( LHashRate );
+      finally
+        LHashRate.Free;
+      end;
+    end;
+  end;
+
 end;
 
 function TPCSafeBox.GetBlockInfo(ABlockNumber: Cardinal): TOperationBlock;

--- a/src/core/UConst.pas
+++ b/src/core/UConst.pas
@@ -129,10 +129,10 @@ Const
 
   CT_MagicNetIdentification = {$IFDEF PRODUCTION}$0A043580{$ELSE}$05000004{$ENDIF};
 
-  CT_NetProtocol_Version: Word = 9; // TODO Need to upgrade to 10 after V5 Hardfork
+  CT_NetProtocol_Version: Word = 10;
   // IMPORTANT NOTE!!!
   // NetProtocol_Available MUST BE always >= NetProtocol_version
-  CT_NetProtocol_Available: Word = {$IFDEF PRODUCTION}11{$ELSE}11{$ENDIF};
+  CT_NetProtocol_Available: Word = {$IFDEF PRODUCTION}12{$ELSE}12{$ENDIF};
 
   CT_MaxAccountOperationsPerBlockWithoutFee = 1;
 
@@ -195,7 +195,7 @@ Const
   CT_OpSubtype_Data_Signer                = 103;
   CT_OpSubtype_Data_Receiver              = 104;
 
-  CT_ClientAppVersion : String = {$IFDEF PRODUCTION}'5.1'{$ELSE}{$IFDEF TESTNET}'TESTNET 5.1'{$ELSE}{$ENDIF}{$ENDIF};
+  CT_ClientAppVersion : String = {$IFDEF PRODUCTION}'5.2'{$ELSE}{$IFDEF TESTNET}'TESTNET 5.2'{$ELSE}{$ENDIF}{$ENDIF};
 
   CT_Discover_IPs = {$IFDEF PRODUCTION}'bpascal1.dynamic-dns.net;bpascal2.dynamic-dns.net;pascalcoin1.dynamic-dns.net;pascalcoin2.dynamic-dns.net;pascalcoin1.dns1.us;pascalcoin2.dns1.us;pascalcoin1.dns2.us;pascalcoin2.dns2.us'
                     {$ELSE}'pascaltestnet1.dynamic-dns.net;pascaltestnet2.dynamic-dns.net;pascaltestnet1.dns1.us;pascaltestnet2.dns1.us'{$ENDIF};

--- a/src/core/UCrypto.pas
+++ b/src/core/UCrypto.pas
@@ -134,7 +134,8 @@ Type
     Function Multiply(int : Int64) : TBigNum; overload;
     Function LShift(nbits : Integer) : TBigNum;
     Function RShift(nbits : Integer) : TBigNum;
-    Function CompareTo(BN : TBigNum) : Integer;
+    Function CompareTo(BN : TBigNum) : Integer; overload;
+    Function CompareTo(int : Int64) : Integer; overload;
     Function Divide(BN : TBigNum) : TBigNum; overload;
     Function Divide(int : Int64) : TBigNum; overload;
     Procedure Divide(dividend, remainder : TBigNum); overload;
@@ -861,6 +862,17 @@ begin
   {$ELSE}
   Result := FBigInteger.CompareTo(BN.FBigInteger);
   {$ENDIF}
+end;
+
+function TBigNum.CompareTo(int: Int64): Integer;
+var LBigNum : TBigNum;
+begin
+  LBigNum := TBigNum.Create(int);
+  try
+    Result := CompareTo( LBigNum );
+  finally
+    LBigNum.Free;
+  end;
 end;
 
 function TBigNum.Copy: TBigNum;

--- a/src/core/UNetProtocol.pas
+++ b/src/core/UNetProtocol.pas
@@ -80,6 +80,8 @@ Const
   CT_MAX_OPS_PER_BLOCKCHAINOPERATIONS = 10000;
   CT_MAX_SAFEBOXCHUNK_BLOCKS = 30000;
 
+  CT_MIN_NetProtocol_Use_Aggregated_Hashrate = 12;
+
 Type
   {
   Net Protocol:
@@ -369,6 +371,7 @@ Type
     FTcpIpClient : TNetTcpIpClient;
     FRemoteOperationBlock : TOperationBlock;
     FRemoteAccumulatedWork : UInt64;
+    FRemoteAggregatedHashrate : TBigNum;
     FLastHelloTS : TTickCount;
     FLastDataReceivedTS : TTickCount;
     FLastDataSendedTS : TTickCount;
@@ -1647,6 +1650,7 @@ Const CT_LogSender = 'GetNewBlockChainFromClient';
         BlocksList := TList<TPCOperationsComp>.Create;
         try
           finished := NOT Do_GetOperationsBlock(Bank,start,start + 100,30000,false,BlocksList);
+          finished := (finished) or (BlocksList.Count<=0);
           i := 0;
           while (i<BlocksList.Count) And (Not finished) do begin
             OpComp := TPCOperationsComp(BlocksList[i]);
@@ -1682,15 +1686,10 @@ Const CT_LogSender = 'GetNewBlockChainFromClient';
           BlocksList.Free;
         end;
         start := Bank.BlocksCount;
-      until (Bank.BlocksCount=Connection.FRemoteOperationBlock.block+1) Or (finished)
-        // Allow to do not download ALL new blockchain in a separate folder, only needed blocks!
-        Or (Bank.SafeBox.WorkSum > (TNode.Node.Bank.SafeBox.WorkSum + $FFFFFFFF) );
-      // New Build 1.5 more work vs more high
-      // work = SUM(target) of all previous blocks (Int64)
-      // -----------------------------
-      // Before of version 1.5 was: "if Bank.BlocksCount>TNode.Node.Bank.BlocksCount then ..."
-      // Starting on version 1.5 is: "if Bank.WORK > MyBank.WORK then ..."
-      if Bank.SafeBox.WorkSum > TNode.Node.Bank.SafeBox.WorkSum then begin
+      until (Bank.BlocksCount>=Connection.FRemoteOperationBlock.block+1) Or (finished);
+      // New Build 5.2 more aggregated hashrate
+      // More work equals to SUM( Hashrate ) of all previous blocks > my SUM( Hashsrate )
+      if Bank.SafeBox.AggregatedHashrate.CompareTo( TNode.Node.Bank.SafeBox.AggregatedHashrate ) > 0 then begin
         oldBlockchainOperations := TOperationsHashTree.Create;
         try
           TNode.Node.DisableNewBlocks;
@@ -1759,12 +1758,26 @@ Const CT_LogSender = 'GetNewBlockChainFromClient';
         finally
           oldBlockchainOperations.Free;
         end;
-      end else begin
-        if (Not IsAScam) And (Connection.FRemoteAccumulatedWork > TNode.Node.Bank.SafeBox.WorkSum) then begin
-          // Possible scammer!
+      end else if (Not IsAScam) then begin // If it was as Scam, then was disconnected previously
+        if (Connection.FRemoteAccumulatedWork > Bank.SafeBox.WorkSum) then begin
+          // Possible scammer because obtained is lower than claimed!
           Connection.DisconnectInvalidClient(false,Format('Possible scammer! Says blocks:%d Work:%d - Obtained blocks:%d work:%d',
             [Connection.FRemoteOperationBlock.block+1,Connection.FRemoteAccumulatedWork,
              Bank.BlocksCount,Bank.SafeBox.WorkSum]));
+        end else if (Connection.FRemoteAggregatedHashrate.CompareTo( Bank.SafeBox.AggregatedHashrate )>0) then begin
+          // Possible scammer because obtained Hashrate is lower than claimed!
+          Connection.DisconnectInvalidClient(false,Format('Possible scammer! Says blocks:%d Aggregated HashRate:%s - Obtained blocks:%d HashRate:%s',
+            [Connection.FRemoteOperationBlock.block+1,Connection.FRemoteAggregatedHashrate.ToDecimal,
+             Bank.BlocksCount,Bank.SafeBox.AggregatedHashrate.ToDecimal]));
+        end else begin
+          TLog.NewLog(ltinfo,CT_LogSender, Format('Nothing made! Says blocks:%d Aggregated HashRate:%s - Obtained blocks:%d HashRate:%s Current blocks:%d HashRate:%s',
+            [Connection.FRemoteOperationBlock.block+1,
+             Connection.FRemoteAggregatedHashrate.ToDecimal,
+             Bank.BlocksCount,Bank.SafeBox.AggregatedHashrate.ToDecimal,
+             TNode.Node.Bank.SafeBox.BlocksCount,
+             TNode.Node.Bank.SafeBox.AggregatedHashrate.ToDecimal
+             ]));
+
         end;
       end;
     finally
@@ -2521,6 +2534,7 @@ end;
 constructor TNetConnection.Create(AOwner: TComponent);
 begin
   inherited;
+  FRemoteAggregatedHashrate := TBigNum.Create;
   FIsConnecting:=False;
   FIsDownloadingBlocks := false;
   FHasReceivedData := false;
@@ -2571,6 +2585,7 @@ begin
     FreeAndNil(FBufferLock);
     FreeAndNil(FBufferReceivedOperationsHash);
     FreeAndNil(FBufferToSendOperations);
+    FreeAndNil(FRemoteAggregatedHashrate);
     inherited;
   End;
 end;
@@ -3504,6 +3519,7 @@ var op, myLastOp : TPCOperationsComp;
     connection_ts : Cardinal;
    Duplicate : TNetConnection;
    RawAccountKey : TRawBytes;
+   LRawAggregatedHashrate : TRawBytes;
    other_version : String;
    isFirstHello : Boolean;
    lastTimestampDiff : Integer;
@@ -3578,12 +3594,21 @@ Begin
           ClientAppVersion := other_version;
           if (DataBuffer.Size-DataBuffer.Position>=SizeOf(FRemoteAccumulatedWork)) then begin
             DataBuffer.Read(FRemoteAccumulatedWork,SizeOf(FRemoteAccumulatedWork));
-            TLog.NewLog(ltdebug,ClassName,'Received HELLO with height: '+inttostr(op.OperationBlock.block)+' Accumulated work '+IntToStr(FRemoteAccumulatedWork)+ ' Remote block: '+TPCOperationsComp.OperationBlockToText(FRemoteOperationBlock));
           end;
         end;
-        //
+        if HeaderData.protocol.protocol_available>=CT_MIN_NetProtocol_Use_Aggregated_Hashrate then begin
+          // Read Aggregated Hashrate value
+          if TStreamOp.ReadAnsiString(DataBuffer,LRawAggregatedHashrate)>=0 then begin
+            FRemoteAggregatedHashrate.RawValue := LRawAggregatedHashrate;
+            FRemoteAccumulatedWork := 0;
+          end;
+        end;
+        TLog.NewLog(ltdebug,ClassName,'Received HELLO with height: '+inttostr(op.OperationBlock.block)+' Accumulated work|hashrate '+IntToStr(FRemoteAccumulatedWork)+'|'+FRemoteAggregatedHashrate.ToDecimal+' Remote block: '+TPCOperationsComp.OperationBlockToText(FRemoteOperationBlock));
+        // Detect if is a higher work blockchain
         if (FRemoteAccumulatedWork>TNode.Node.Bank.SafeBox.WorkSum) Or
-          ((FRemoteAccumulatedWork=0) And (TNetData.NetData.FMaxRemoteOperationBlock.block<FRemoteOperationBlock.block)) then begin
+          ((FRemoteAccumulatedWork=0) And (TNetData.NetData.FMaxRemoteOperationBlock.block<FRemoteOperationBlock.block)) Or
+          ((FRemoteAggregatedHashrate.CompareTo(TNode.Node.Bank.SafeBox.AggregatedHashrate)>0))
+          then begin
           TNetData.NetData.FMaxRemoteOperationBlock := FRemoteOperationBlock;
           if TPCThread.ThreadClassFound(TThreadGetNewBlockChainFromClient,nil)<0 then begin
             TThreadGetNewBlockChainFromClient.Create;
@@ -3831,6 +3856,7 @@ var operationsComp : TPCOperationsComp;
     Result := True;
   end;
 var c : Cardinal;
+  LRawAggregatedHashrate : TRawBytes;
 begin
   errors := '';
   DoDisconnect := true;
@@ -3847,14 +3873,24 @@ begin
         exit;
       end else begin
         DoDisconnect := false;
-        DataBuffer.Read(FRemoteAccumulatedWork,SizeOf(FRemoteAccumulatedWork));
-        if operationsComp.IsOnlyOperationBlock then begin
-          TLog.NewLog(ltdebug,ClassName,'Received NEW FAST PROPAGATION BLOCK with height: '+inttostr(operationsComp.OperationBlock.block)+' Accumulated work '+IntToStr(FRemoteAccumulatedWork)+' from '+ClientRemoteAddr);
+        if AHeaderData.protocol.protocol_available>=CT_MIN_NetProtocol_Use_Aggregated_Hashrate then begin
+          TStreamOp.ReadAnsiString(DataBuffer,LRawAggregatedHashrate);
+          FRemoteAggregatedHashrate.RawValue := LRawAggregatedHashrate;
+          FRemoteAccumulatedWork := 0; // No needed
         end else begin
-          TLog.NewLog(ltdebug,ClassName,'Received NEW BLOCK with height: '+inttostr(operationsComp.OperationBlock.block)+' Accumulated work '+IntToStr(FRemoteAccumulatedWork)+' from '+ClientRemoteAddr);
+          DataBuffer.Read(FRemoteAccumulatedWork,SizeOf(FRemoteAccumulatedWork));
+          FRemoteAggregatedHashrate.Value:=0;
+        end;
+        if operationsComp.IsOnlyOperationBlock then begin
+          TLog.NewLog(ltdebug,ClassName,'Received NEW FAST PROPAGATION BLOCK with height: '+inttostr(operationsComp.OperationBlock.block)+' Accumulated values '+IntToStr(FRemoteAccumulatedWork)+' '+FRemoteAggregatedHashrate.ToDecimal+' from '+ClientRemoteAddr);
+        end else begin
+          TLog.NewLog(ltdebug,ClassName,'Received NEW BLOCK with height: '+inttostr(operationsComp.OperationBlock.block)+' Accumulated values '+IntToStr(FRemoteAccumulatedWork)+' '+FRemoteAggregatedHashrate.ToDecimal+' from '+ClientRemoteAddr);
         end;
         FRemoteOperationBlock := operationsComp.OperationBlock;
-        if (FRemoteAccumulatedWork>TNode.Node.Bank.SafeBox.WorkSum) then begin
+        if (FRemoteAccumulatedWork>TNode.Node.Bank.SafeBox.WorkSum)
+           or
+           (FRemoteAggregatedHashrate.CompareTo( TNode.Node.Bank.SafeBox.AggregatedHashrate ) > 0)
+          then begin
           if (operationsComp.OperationBlock.block=TNode.Node.Bank.BlocksCount) then begin
             // New block candidate:
             if (operationsComp.IsOnlyOperationBlock) then begin
@@ -4409,6 +4445,8 @@ var data : TStream;
   nsarr : TNodeServerAddressArray;
   w : Word;
   currunixtimestamp : Cardinal;
+  LRawAggregatedHashrate : TRawBytes;
+  LUInt64 : UInt64;
 begin
   Result := false;
   if Not Connected then exit;
@@ -4441,9 +4479,17 @@ begin
     end;
     // Send client version
     TStreamOp.WriteAnsiString(data,TEncoding.ASCII.GetBytes(TNode.NodeVersion));
-    // Build 1.5 send accumulated work
-    data.Write(TNode.Node.Bank.SafeBox.WorkSum,SizeOf(TNode.Node.Bank.SafeBox.WorkSum));
-    //
+    // Send Aggregated Hashsrate based on network protocol available version
+    if FNetProtocolVersion.protocol_available>=CT_MIN_NetProtocol_Use_Aggregated_Hashrate then begin
+      LUInt64:=0;
+      data.Write(LUInt64,SizeOf(LUInt64));
+      LRawAggregatedHashrate := TNode.Node.Bank.SafeBox.AggregatedHashrate.RawValue;
+      TStreamOp.WriteAnsiString(data,LRawAggregatedHashrate);
+    end else begin
+      // If version older than 5.2 then send previous WorkSum value instead of AggregatedHashate
+      data.Write(TNode.Node.Bank.SafeBox.WorkSum,SizeOf(TNode.Node.Bank.SafeBox.WorkSum));
+    end;
+
     Send(NetTranferType,CT_NetOp_Hello,0,request_id,data);
     Result := Client.Connected;
     FLastHelloTS := TPlatform.GetTickCount;
@@ -4477,6 +4523,7 @@ var data : TStream;
   c : Cardinal;
   i : Integer;
   opRef : TOpReference;
+  LRawAggregatedHashrate : TRawBytes;
 begin
   Result := false;
   if Not Connected then exit;
@@ -4505,7 +4552,14 @@ begin
       // Will send a FAST PROPAGATION BLOCK as described at PIP-0015
       netOp := CT_NetOp_NewBlock_Fast_Propagation;
       NewBlock.SaveBlockToStream(netOp = CT_NetOp_NewBlock_Fast_Propagation,data); // Will save all only if not FAST PROPAGATION
-      data.Write(TNode.Node.Bank.SafeBox.WorkSum,SizeOf(TNode.Node.Bank.SafeBox.WorkSum));
+      // Send Aggregated Hashsrate based on network protocol available version
+      if FNetProtocolVersion.protocol_available>=CT_MIN_NetProtocol_Use_Aggregated_Hashrate then begin
+        LRawAggregatedHashrate := TNode.Node.Bank.SafeBox.AggregatedHashrate.RawValue;
+        TStreamOp.WriteAnsiString(data,LRawAggregatedHashrate);
+      end else begin
+        // If version older than 5.2 then send previous WorkSum value instead of AggregatedHashate
+        data.Write(TNode.Node.Bank.SafeBox.WorkSum,SizeOf(TNode.Node.Bank.SafeBox.WorkSum));
+      end;
       if (netOp = CT_NetOp_NewBlock_Fast_Propagation) then begin
         // Fill with OpReference data:
         c := NewBlock.OperationsHashTree.OperationsCount;
@@ -4773,57 +4827,54 @@ end;
 
 procedure TThreadGetNewBlockChainFromClient.BCExecute;
 Var i,j : Integer;
-  maxWork : UInt64;
+  LMaxAggregatedTarget : UInt64;
   candidates : TList<TNetConnection>;
   lop : TOperationBlock;
   nc : TNetConnection;
+  LMaxAggregatedHashrate : TBigNum;
 begin
   if Not TNode.Node.UpdateBlockchain then Exit;
 
   // Search better candidates:
   candidates := TList<TNetConnection>.Create;
+  LMaxAggregatedHashrate := TBigNum.Create(0);
   try
     lop := CT_OperationBlock_NUL;
     TNetData.NetData.FMaxRemoteOperationBlock := CT_OperationBlock_NUL;
     // First round: Find by most work
-    maxWork := 0;
+    LMaxAggregatedTarget := 0;
     j := TNetData.NetData.ConnectionsCountAll;
     nc := Nil;
     for i := 0 to j - 1 do begin
       if TNetData.NetData.GetConnection(i,nc) then begin
-        if (nc.FRemoteAccumulatedWork>maxWork) And (nc.FRemoteAccumulatedWork>TNode.Node.Bank.SafeBox.WorkSum) then begin
-          maxWork := nc.FRemoteAccumulatedWork;
-        end;
         // Preventing downloading
         if nc.FIsDownloadingBlocks then exit;
+        //
+        if (nc.FRemoteAggregatedHashrate.CompareTo( LMaxAggregatedHashrate )>0) and (nc.FRemoteAggregatedHashrate.CompareTo( TNode.Node.Bank.SafeBox.AggregatedHashrate )>0) then begin
+          LMaxAggregatedHashrate.RawValue := nc.FRemoteAggregatedHashrate.RawValue;
+        end;
+        if (nc.FRemoteAccumulatedWork>LMaxAggregatedTarget) And (nc.FRemoteAccumulatedWork>TNode.Node.Bank.SafeBox.WorkSum) then begin
+          LMaxAggregatedTarget := nc.FRemoteAccumulatedWork;
+        end;
       end;
     end;
-    if (maxWork>0) then begin
+    if (LMaxAggregatedHashrate.CompareTo( 1 ) > 0) then begin
+      // Search by Aggregated Hashrate
       for i := 0 to j - 1 do begin
         If TNetData.NetData.GetConnection(i,nc) then begin
-          if (nc.FRemoteAccumulatedWork>=maxWork) then begin
+          if (nc.FRemoteAggregatedHashrate.CompareTo(LMaxAggregatedHashrate)>=0) then begin
             candidates.Add(nc);
             lop := nc.FRemoteOperationBlock;
           end;
         end;
       end;
-    end;
-    // Second round: Find by most height
-    if candidates.Count=0 then begin
+    end else if (LMaxAggregatedTarget>0) then begin
+      // Not found searching by Aggregated Hashrate, searching by Aggregated Target
       for i := 0 to j - 1 do begin
-        if (TNetData.NetData.GetConnection(i,nc)) then begin
-          if (nc.FRemoteOperationBlock.block>=TNode.Node.Bank.BlocksCount) And
-             (nc.FRemoteOperationBlock.block>=lop.block) then begin
-             lop := nc.FRemoteOperationBlock;
-          end;
-        end;
-      end;
-      if (lop.block>0) then begin
-        for i := 0 to j - 1 do begin
-          If (TNetData.NetData.GetConnection(i,nc)) then begin
-            if (nc.FRemoteOperationBlock.block>=lop.block) then begin
-               candidates.Add(nc);
-            end;
+        If TNetData.NetData.GetConnection(i,nc) then begin
+          if (nc.FRemoteAccumulatedWork>=LMaxAggregatedTarget) then begin
+            candidates.Add(nc);
+            lop := nc.FRemoteOperationBlock;
           end;
         end;
       end;
@@ -4834,9 +4885,10 @@ begin
       i := 0;
       if (candidates.Count>1) then i := Random(candidates.Count); // i = 0..count-1
       nc := TNetConnection(candidates[i]);
-      TNetData.NetData.GetNewBlockChainFromClient(nc,Format('Candidate block: %d sum: %d',[nc.FRemoteOperationBlock.block,nc.FRemoteAccumulatedWork]));
+      TNetData.NetData.GetNewBlockChainFromClient(nc,Format('Candidate block: %d Aggregated: %d %s',[nc.FRemoteOperationBlock.block,nc.FRemoteAccumulatedWork,nc.FRemoteAggregatedHashrate.ToDecimal]));
     end;
   finally
+    LMaxAggregatedHashrate.Free;
     candidates.Free;
   end;
 end;

--- a/src/core/UPoolMinerThreads.pas
+++ b/src/core/UPoolMinerThreads.pas
@@ -47,7 +47,7 @@ Type
 
   TCustomMinerDeviceThreadClass = Class of TCustomMinerDeviceThread;
 
-  TOnFoundNonce = Procedure(Sender : TCustomMinerDeviceThread; Timestamp, nOnce : Cardinal) of object;
+  TOnFoundNonce = Procedure(Sender : TCustomMinerDeviceThread; const AUsedMinerValuesForWork : TMinerValuesForWork; ATimestamp, AnOnce : Cardinal; const APoW : TRawBytes) of object;
 
   { TPoolMinerThread }
 
@@ -531,7 +531,7 @@ begin
   if (TBaseType.BinStrComp(LHash,usedMinerValuesForWork.target_pow)<=0) then begin
     inc(FGlobaDeviceStats.WinsCount);
     FPoolMinerThread.OnMinerNewBlockFound(self,usedMinerValuesForWork,Timestamp,nOnce,LHash);
-    If Assigned(FOnFoundNOnce) then FOnFoundNOnce(Self,Timestamp,nOnce);
+    If Assigned(FOnFoundNOnce) then FOnFoundNOnce(Self,usedMinerValuesForWork,Timestamp,nOnce,LHash);
   end else begin
     inc(FGlobaDeviceStats.Invalids);
     if LUseRandomHash then
@@ -681,7 +681,7 @@ end;
 procedure TCPUDeviceThread.BCExecute;
 begin
   while not terminated do begin
-    sleep(1);
+    sleep(10);
   end;
   FCPUs:=0;
   CheckCPUs;
@@ -863,7 +863,7 @@ begin
             if FCurrentMinerValuesForWork.version < CT_PROTOCOL_5 then
               roundsToDo := 20
             else
-              roundsToDo := 200;
+              roundsToDo := 200+Random(200);
           end else begin
             roundsToDo := 10000;
           end;
@@ -1012,6 +1012,7 @@ begin
   FResetNOnce:=True;
   FJobNum := 0;
   inherited Create(false);
+  Priority := tpHigher;
 end;
 
 destructor TCPUOpenSSLMinerThread.Destroy;

--- a/src/pascalcoin_miner.pp
+++ b/src/pascalcoin_miner.pp
@@ -40,7 +40,7 @@ type
     procedure OnConnectionStateChanged(Sender : TObject);
     procedure OnDeviceStateChanged(Sender : TObject);
     procedure OnMinerValuesChanged(Sender : TObject);
-    procedure OnFoundNOnce(Sender : TCustomMinerDeviceThread; Timestamp, nOnce : Cardinal);
+    procedure OnFoundNOnce(Sender : TCustomMinerDeviceThread; const AUsedMinerValuesForWork : TMinerValuesForWork; ATimestamp, AnOnce : Cardinal; const APoW : TRawBytes);
     procedure WriteLine(nline : Integer; txt : String);
     procedure OnInThreadNewLog(logtype : TLogType; Time : TDateTime; ThreadID : TThreadID; Const sender, logtext : AnsiString);
   protected
@@ -142,10 +142,10 @@ begin
   end;
 end;
 
-procedure TPascalMinerApp.OnFoundNOnce(Sender: TCustomMinerDeviceThread; Timestamp, nOnce: Cardinal);
+procedure TPascalMinerApp.OnFoundNOnce(Sender : TCustomMinerDeviceThread; const AUsedMinerValuesForWork : TMinerValuesForWork; ATimestamp, AnOnce : Cardinal; const APoW : TRawBytes);
 begin
-  WriteLine(CT_Line_LastFound + FDeviceThreads.Count,FormatDateTime('hh:nn:ss',now)+' Block:'+IntToStr(Sender.MinerValuesForWork.block)+' NOnce:'+Inttostr(nOnce)+
-    ' Timestamp:'+inttostr(Timestamp)+' Miner:'+Sender.MinerValuesForWork.payload_start.ToPrintable);
+  WriteLine(CT_Line_LastFound + FDeviceThreads.Count,FormatDateTime('hh:nn:ss',now)+' Block:'+IntToStr(Sender.MinerValuesForWork.block)+' NOnce:'+Inttostr(AnOnce)+
+    ' Timestamp:'+inttostr(ATimestamp)+' Miner:'+Sender.MinerValuesForWork.payload_start.ToPrintable);
 end;
 
 procedure TPascalMinerApp.WriteLine(nline: Integer; txt: String);
@@ -238,6 +238,15 @@ var
         Terminate;
         exit;
       end;
+
+      If Not FileExists(ExtractFileDir(ExeName)+PathDelim+CT_OpenCL_FileName) then begin
+        Writeln('**********************');
+        Writeln('OpenCL file not found!');
+        Writeln('File: ',CT_OpenCL_FileName);
+        Terminate;
+        Exit;
+      end;
+
       strl := TStringList.Create;
       try
         if (d<0) then begin
@@ -437,14 +446,6 @@ begin
       ShowGPUDrivers;
       Exit;
     end;
-
-    If Not FileExists(ExtractFileDir(ExeName)+PathDelim+CT_OpenCL_FileName) then begin
-      Writeln('**********************');
-      Writeln('OpenCL file not found!');
-      Writeln('File: ',CT_OpenCL_FileName);
-      Exit;
-    end;
-
 
     If HasOption('s','server') then begin
       s := Trim(GetOptionValue('s','server'));


### PR DESCRIPTION
- Fixed important bug caused by bad calculated "more work" blockchain found by Herman Schoenfeld (herman@sphere10.com)
- NAT limited to 7 seconds by default as proposed by Herman Schoenfeld (herman@sphere10.com) in order to minimize a warp timestamp attack.
- Fix invalid "balance" rounded decimals value caused by FPC (daemon or Linux versions)
- Improvements on hashlib4pascal library by Ugochukwu Mmaduekwe <https://github.com/Xor-el>
- Minor improvements and fixed bugs