### PR TITLE
Fix issue #207 "out of memory" when compiled with FreePascal

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -69,7 +69,10 @@
 
   // Activate GNUGETTEXT library
   {$DEFINE USE_GNUGETTEXT}
-
+  
+  // Activate usage of TPCTemporalFileStream instead of TBytes in order to minimize mem usage
+  // This also fixes issue #207 High memory usage on FreePascal compiler
+  {$DEFINE USE_BIGBLOCKS_MEM_ON_DISK}
 
 { ********************************************************************
   Don't touch more code, it will addapt based on your preferences

--- a/src/core/UPCTemporalFileStream.pas
+++ b/src/core/UPCTemporalFileStream.pas
@@ -41,7 +41,7 @@ Type
 
 implementation
 
-Uses ULog, UNode;
+Uses {$IFDEF HIGHLOG}ULog, {$ENDIF} UNode;
 
 { TPCTemporalFileStream }
 
@@ -63,18 +63,18 @@ begin
     end;
     inc(i);
   until (Not (FileExists(LFileName)) or (i>5000));
-  TLog.NewLog(ltdebug,ClassName,Format('Creating a new Temporal file Stream: %s',[LFileName]));
+  {$IFDEF HIGHLOG}TLog.NewLog(ltdebug,ClassName,Format('Creating a new Temporal file Stream: %s',[LFileName]));{$ENDIF}
   inherited Create(LFileName,fmCreate+fmShareDenyWrite);
   FTemporalFileName:=LFileName;
 end;
 
 destructor TPCTemporalFileStream.Destroy;
-var LSize : Integer;
+{$IFDEF HIGHLOG}var LSize : Integer;{$ENDIF}
 begin
-  LSize := Size;
+  {$IFDEF HIGHLOG}LSize := Size;{$ENDIF}
   inherited Destroy;
   if FTemporalFileName<>'' then begin
-    TLog.NewLog(ltdebug,ClassName,Format('Deleting a Temporal file Stream (%d bytes): %s',[LSize, FTemporalFileName]));
+    {$IFDEF HIGHLOG}TLog.NewLog(ltdebug,ClassName,Format('Deleting a Temporal file Stream (%d bytes): %s',[LSize, FTemporalFileName]));{$ENDIF}
     DeleteFile(FTemporalFileName);
   end;
 end;

--- a/src/tests/PascalCoinUnitTests.lpr
+++ b/src/tests/PascalCoinUnitTests.lpr
@@ -5,7 +5,7 @@ program UPascalCoinUnitTests;
 uses
   Interfaces, Forms, GuiTestRunner, UCommon.Collections, UCommon.Tests,
   UCommon.Collections.Tests, UMemory.Tests, UThread.Tests, URandomHash.Tests,
-  URandomHash2.Tests, URandomHash;
+  URandomHash2.Tests, URandomHash, ubasetypes.tests;
 
 {$R *.res}
 

--- a/src/tests/ubasetypes.tests.pas
+++ b/src/tests/ubasetypes.tests.pas
@@ -1,0 +1,60 @@
+unit UBaseTypes.Tests;
+
+{$mode delphi}
+{$H+}
+{$modeswitch nestedprocvars}
+
+interface
+
+uses
+  Classes, SysUtils, fpcunit,
+  testregistry,
+  UBaseTypes;
+
+type
+
+  { TBytesBufferTest }
+
+  TBytesBufferTest = class(TTestCase)
+    published
+      procedure Test_SaveToStream;
+  end;
+
+implementation
+
+{ TBytesBufferTest }
+
+procedure TBytesBufferTest.Test_SaveToStream;
+var Lbb, Lbb2 : TBytesBuffer;
+  LStream : TStream;
+  LBuffer : TBytes;
+  i : Integer;
+begin
+  SetLength(LBuffer,1000 + Random(1000) );
+  for i:= 0 to High(LBuffer) do begin
+    LBuffer[i] := Random(250)+1;
+  end;
+  Lbb := TBytesBuffer.Create(Random(1000)+100);
+  Lbb.Add(LBuffer);
+  Lbb2 := TBytesBuffer.CreateCopy(Lbb);
+  LStream := TMemoryStream.Create;
+  try
+    Lbb.SaveToStream(LStream);
+    Self.AssertEquals('T1',0,Lbb.Compare(Lbb2));
+    Self.AssertEquals('T2',0,Lbb.Compare(LStream));
+    Lbb2.Clear;
+    Lbb2.LoadFromStream(LStream);
+    Self.AssertEquals('T3',0,Lbb.Compare(Lbb2));
+  finally
+    Lbb.Free;
+    Lbb2.Free;
+  end;
+end;
+
+
+initialization
+  Randomize;
+  RegisterTest(TBytesBufferTest);
+end.
+
+


### PR DESCRIPTION
**USE_BIGBLOCKS_MEM_ON_DISK** directive is used in order to prevent a FreePascal issue with Heap allocation strategy that reuses big blocks of disposed memory and fragments it, this causes that when a new big block of same size that previously freeded mem is needed it will not reuse because has been fragmented...

Tested on FPC version 3.2.0 (2020-11-03) and order versions
Defragmention documented here: https://www.freepascal.org/docs-html/current/prog/progsu172.html
This issue is not detected on current Delphi memory manager (Tested on Delphi 10.3.2)

**FIXED** using USE_BIGBLOCKS_MEM_ON_DISK directive that activates TPCTemporalFileStream usage instead of TBytes (memory) usage

https://github.com/PascalCoinDev/PascalCoin/issues/207