### PR TITLE
GUI Experimental Bug Fixes 5 (Proper work around implemented for TList.ToArray)

### DIFF
--- a/src/gui-experimental/UFRMAccountSelect.pas
+++ b/src/gui-experimental/UFRMAccountSelect.pas
@@ -169,10 +169,10 @@ procedure TSearchThread.BCExecute;
         isValid := TAccountComp.IsAccountForSale(account.accountInfo);
       end;
       If IsValid and (FSearchValues.onlyForPublicSale) then begin
-        isValid := (TAccountComp.IsAccountForSale(account.accountInfo)) And (Not TAccountComp.IsAccountForSaleOrSwapAcceptingTransactions(account, FSearchValues.SafeBox.BlocksCount, FSearchValues.SafeBox.CurrentProtocol, nil));  // Skybuck: todo check/debug if this is safe
+        isValid := (TAccountComp.IsAccountForSale(account.accountInfo)) And (Not TAccountComp.IsAccountForSaleOrSwapAcceptingTransactions(account, FSearchValues.SafeBox.BlocksCount, FSearchValues.SafeBox.CurrentProtocol, nil));  // Skybuck: todo check/debug !
       end;
       If IsValid and (FSearchValues.onlyForPrivateSaleToMe) then begin
-        isValid := ( TAccountComp.IsAccountForSaleOrSwapAcceptingTransactions(account,FSearchValues.SafeBox.BlocksCount, FSearchValues.SafeBox.CurrentProtocol, nil)) And // Skybuck: todo check/debug if this is safe
+        isValid := ( TAccountComp.IsAccountForSaleOrSwapAcceptingTransactions(account,FSearchValues.SafeBox.BlocksCount, FSearchValues.SafeBox.CurrentProtocol, nil)) And // Skybuck: todo check/debug !
           (Assigned(FSearchValues.inWalletKeys)) And (FSearchValues.inWalletKeys.IndexOfAccountKey(account.accountInfo.new_publicKey)>=0);
       end;
       If IsValid then begin

--- a/src/gui-experimental/UFRMOperation.pas
+++ b/src/gui-experimental/UFRMOperation.pas
@@ -294,8 +294,8 @@ loop_start:
         if signerAccount.balance>DefaultFee then _fee := DefaultFee
         else _fee := signerAccount.balance;
         if (rbListAccountForPublicSale.Checked) then begin
-          LHashLock := CT_HashLock_NUL; // Skybuck: check or debug ! passed in function below !
-          // Skybuck: LNewAccountState parameter added, check or debug this later ! passed in function below !
+          LHashLock := CT_HashLock_NUL; // Skybuck: check or debug ! LHashLock zero value array passed in function below perhaps replace with correctly filled hash array !
+          // Skybuck: LNewAccountState parameter added, check or debug this later ! passed in function below ! LNewAccountState is not set yet !
           op := TOpListAccountForSaleOrSwap.CreateListAccountForSaleOrSwap(FNode.Bank.SafeBox.CurrentProtocol, LNewAccountState, signerAccount.account,signerAccount.n_operation+1+iAcc, account.account,_salePrice,_fee, destAccount.account,CT_TECDSA_Public_Nul,0,wk.PrivateKey,LHashLock, FOperationPayload);
         end else if (rbListAccountForPrivateSale.Checked) then begin
           op := TOpListAccountForSaleOrSwap.CreateListAccountForSaleOrSwap(FNode.Bank.SafeBox.CurrentProtocol, LNewAccountState, signerAccount.account,signerAccount.n_operation+1+iAcc, account.account,_salePrice,_fee, destAccount.account,_newOwnerPublicKey,_lockedUntil,wk.PrivateKey,LHashLock, FOperationPayload);
@@ -320,7 +320,7 @@ loop_start:
         if not UpdateOpChangeInfo(account,signerAccount,_changeName,_newName,_changeType,_newType,errors) then raise Exception.Create(errors);
         if signerAccount.balance>DefaultFee then _fee := DefaultFee
         else _fee := signerAccount.balance;
-        // Skybuck: check or debug LChangeData and LNewData !!
+        // Skybuck: check or debug LChangeData and LNewData !! (newly added, no correct values yet set in these two variables !?!)
         op := TOpChangeAccountInfo.CreateChangeAccountInfo(FNode.Bank.SafeBox.CurrentProtocol,signerAccount.account,signerAccount.n_operation+1,account.account,wk.PrivateKey,false,CT_TECDSA_Public_Nul,
            _changeName,_newName,_changeType,_newType,LChangeData,LNewData,_fee,FOperationPayload);
         {%endregion}
@@ -1255,7 +1255,6 @@ Var payload_u : AnsiString;
 begin
   valid := false;
   payload_encrypted := Nil;
-//  FEncodedPayload := Nil;  // Skybuck: old/deprecated
   FOperationPayload.payload_raw := nil;
   errors := 'Unknown error';
   payload_u := memoPayload.Lines.Text;
@@ -1359,7 +1358,6 @@ begin
       lblEncryptionErrors.Caption := errors;
       lblPayloadLength.Caption := Format('(%db -> ?)',[length(payload_u)]);
     end;
-//    FEncodedPayload := payload_encrypted; // Skybuck: old/deprecated
     FOperationPayload.payload_raw := payload_encrypted;
 
     Result := valid;

--- a/src/gui-experimental/UFRMPascalCoinWalletConfig.pas
+++ b/src/gui-experimental/UFRMPascalCoinWalletConfig.pas
@@ -135,12 +135,12 @@ end;
 
 procedure TFRMPascalCoinWalletConfig.bbOpenDataFolderClick(Sender: TObject);
 begin
-//  OpenDocument(PChar(TFolderHelper.GetPascalCoinDataFolder)) // Skybuck: old, don't work no more.
-  // Skybuck: two solutions possible:
+  // Skybuck:TFolderHelper.GetPascalCoinDataFolder don't exist no more replaced with TNode.GetPascalCoinDataFolder
+  // OpenDocument(PChar(TFolderHelper.GetPascalCoinDataFolder))
+  // Two solutions possible:
   // 1: TNode.GetPascalCoinDataFolder
   // 2. TFolderHelper.GetDataFolder(CT_PascalCoin_Data_Folder
-
-  // Skybuck: I will try TNode first if this does not work use solution 2.
+  // I will try TNode first if this does not work use solution 2.
   OpenDocument(PChar(TNode.GetPascalCoinDataFolder));
 end;
 

--- a/src/gui-experimental/UUserInterface.pas
+++ b/src/gui-experimental/UUserInterface.pas
@@ -342,7 +342,6 @@ begin
     FLog.SaveTypes := [];
 
     // Create data directories
-    // Skybuck: using solution 1 for now: TNode.GetPascalCoinDataFolder
     If Not ForceDirectories(TNode.GetPascalCoinDataFolder) then
       raise Exception.Create('Cannot create dir: '+TNode.GetPascalCoinDataFolder);
 
@@ -379,7 +378,6 @@ begin
 
     // Initialise Database
     FNode.Bank.StorageClass := TFileStorage;
-    // skybuck: using solution 1 for now: TNode.GetPascalCoinDataFolder
     TFileStorage(FNode.Bank.Storage).DatabaseFolder := TNode.GetPascalCoinDataFolder+PathDelim+'Data';
     TFileStorage(FNode.Bank.Storage).Initialize;
 
@@ -618,7 +616,6 @@ begin
       FLog.SaveTypes := CT_TLogTypes_ALL
     else
       FLog.SaveTypes := CT_TLogTypes_DEFAULT;
-    // Skybuck: Using solution 1 for now: TNode.GetPascalCoinDataFolder
     FLog.FileName := TNode.GetPascalCoinDataFolder+PathDelim+'PascalCointWallet.log';
   end else begin
     FLog.SaveTypes := [];
@@ -634,7 +631,6 @@ begin
     finally
       FNode.UnlockMempoolWrite;
     end;
-    // Skybuck: Using solution 1 for now: TNode.GetPascalCoinDataFolder
     FNode.NodeLogFilename := TNode.GetPascalCoinDataFolder+PathDelim+'blocks.log';
   end;
   if Assigned(FPoolMiningServer) then begin

--- a/src/libraries/sphere10/UCommon.Collections.pas
+++ b/src/libraries/sphere10/UCommon.Collections.pas
@@ -347,7 +347,7 @@ type
   __TArrayTool_IComparer_T = TArrayTool<__IComparer_T>;
 
 begin
-  Result := TManyComparer<T>.Create( __TArrayTool_IComparer_T.Copy(comparers) ); // Skybuck: re-enabled
+  Result := TManyComparer<T>.Create( __TArrayTool_IComparer_T.Copy(comparers) );
 end;
 
 class function TComparerTool<T>.Many(const comparers: TEnumerable<__IComparer_T>) : IComparer<T>;
@@ -365,7 +365,7 @@ end;
 
 class function TComparerTool<T>.AlwaysEqual : IComparer<T>;
 type
-  __TGlobalComparerFunc_T = TGlobalComparerFunc<T>;  // Skybuck: Re-enabled
+  __TGlobalComparerFunc_T = TGlobalComparerFunc<T>;
 begin
   Result :=  TComparerTool<T>.FromFunc( AlwaysEqualHandler );
 end;
@@ -514,9 +514,9 @@ end;
 
 class function TPredicateTool<T>.OrMany(const APredicates : array of IPredicate<T>) : IPredicate<T>;
 type
-  __TArrayTool_IPredicate_T = TArrayTool<__IPredicate_T>; // Skybuck: Re-enabled
+  __TArrayTool_IPredicate_T = TArrayTool<__IPredicate_T>;
 begin
-  Result := TOrManyPredicate<T>.Create( __TArrayTool_IPredicate_T.Copy( APredicates) ); // Skybuck: Re-enabled
+  Result := TOrManyPredicate<T>.Create( __TArrayTool_IPredicate_T.Copy( APredicates) );
 end;
 
 class function TPredicateTool<T>.OrMany(const APredicates : array of TNestedPredicateFunc<T>) : IPredicate<T>;


### PR DESCRIPTION
1. Reduced the number of Skybuck comments significantly.
2. Removed FGL unit from UCommon.Data.pas.
3. Reverted TFPGList back to TList.
4. Renamed ReturnArrayFromList to ToArrayWorkAround.
5. ToArrayWorkAround now simply returns TList.ToArray.