### PR TITLE
Fix call to TAbstractMem.CheckConsistency

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -34,7 +34,7 @@
   {.$DEFINE TESTNET}
 
   // Activate to define CryptoLib4Pascal by default on all compilations
-  {$DEFINE Use_CryptoLib4Pascal}
+  {.$DEFINE Use_CryptoLib4Pascal}
   // Add the following paths to the project Search Path is this option is used
   // .\libraries\cryptolib4pascal
   // .\libraries\simplebaselib4pascal  

--- a/src/config.inc
+++ b/src/config.inc
@@ -34,7 +34,7 @@
   {.$DEFINE TESTNET}
 
   // Activate to define CryptoLib4Pascal by default on all compilations
-  {.$DEFINE Use_CryptoLib4Pascal}
+  {$DEFINE Use_CryptoLib4Pascal}
   // Add the following paths to the project Search Path is this option is used
   // .\libraries\cryptolib4pascal
   // .\libraries\simplebaselib4pascal  
@@ -68,7 +68,7 @@
   {$DEFINE USE_ABSTRACTMEM}
 
   // Activate GNUGETTEXT library
-  {.$DEFINE USE_GNUGETTEXT}
+  {$DEFINE USE_GNUGETTEXT}
   
   // Activate usage of TPCTemporalFileStream instead of TBytes in order to minimize mem usage
   // This also fixes issue #207 High memory usage on FreePascal compiler

--- a/src/core/UPCRPCFileUtils.pas
+++ b/src/core/UPCRPCFileUtils.pas
@@ -48,7 +48,7 @@ Type
 
 implementation
 
-uses UPCDataTypes, UFileStorage, UNode;
+uses UPCDataTypes, UFileStorage, UNode, UAbstractMem;
 
 { TRPCFileUtils }
 
@@ -90,6 +90,9 @@ var LStrings, LReport : TStrings;
    i, nMax : Integer;
    Lobj : TPCJSONObject;
    Larray : TPCJSONArray;
+   {$IFDEF USE_ABSTRACTMEM}
+   LAbstractMemZoneInfoList : TList<TAbstractMemZoneInfo>;
+   {$ENDIF}
 begin
   if Not ASender.RPCServer.AllowUsePrivateKeys then begin
     AErrorNum := CT_RPC_ErrNum_NotAllowedCall;
@@ -101,26 +104,31 @@ begin
     if AInputParams.GetAsVariant('report').AsBoolean(False) then LReport := LStrings
     else LReport := Nil;
     Lobj := AJSONResponse.GetAsObject('result').GetAsObject('abstractmem');
-    if TNode.Node.Bank.SafeBox.PCAbstractMem.AbstractMem.CheckConsistency(LReport, LTotalUsedSize, LTotalUsedBlocksCount, LTotalLeaksSize, LTotalLeaksBlocksCount) then begin
-      Lobj.GetAsVariant('checkconsistency').Value := True;
-    end else begin
-      Lobj.GetAsVariant('checkconsistency').Value := False;
-    end;
-    Lobj.GetAsVariant('total_used_size').Value := LTotalUsedSize;
-    Lobj.GetAsVariant('total_used_blocks_count').Value := LTotalUsedBlocksCount;
-    Lobj.GetAsVariant('total_leaks_size').Value := LTotalLeaksSize;
-    Lobj.GetAsVariant('total_leaks_blocks_count').Value := LTotalLeaksBlocksCount;
-
-    if Assigned(LReport) then begin
-      Larray := Lobj.GetAsArray('report');
-      i := AInputParams.GetAsVariant('report_start').AsInteger(0);
-      nMax := AInputParams.GetAsVariant('report_max').AsInteger(100);
-      while (nMax>0) and (i>=0) and (i<LStrings.Count-1) do begin
-        Larray.GetAsVariant(Larray.Count).Value := LStrings[i];
-        inc(i);
-        dec(nMax);
+    LAbstractMemZoneInfoList := TList<TAbstractMemZoneInfo>.Create;
+    Try
+      if TNode.Node.Bank.SafeBox.PCAbstractMem.AbstractMem.CheckConsistency(LReport, LAbstractMemZoneInfoList, LTotalUsedSize, LTotalUsedBlocksCount, LTotalLeaksSize, LTotalLeaksBlocksCount) then begin
+        Lobj.GetAsVariant('checkconsistency').Value := True;
+      end else begin
+        Lobj.GetAsVariant('checkconsistency').Value := False;
       end;
-    end;
+      Lobj.GetAsVariant('total_used_size').Value := LTotalUsedSize;
+      Lobj.GetAsVariant('total_used_blocks_count').Value := LTotalUsedBlocksCount;
+      Lobj.GetAsVariant('total_leaks_size').Value := LTotalLeaksSize;
+      Lobj.GetAsVariant('total_leaks_blocks_count').Value := LTotalLeaksBlocksCount;
+
+      if Assigned(LReport) then begin
+        Larray := Lobj.GetAsArray('report');
+        i := AInputParams.GetAsVariant('report_start').AsInteger(0);
+        nMax := AInputParams.GetAsVariant('report_max').AsInteger(100);
+        while (nMax>0) and (i>=0) and (i<LStrings.Count-1) do begin
+          Larray.GetAsVariant(Larray.Count).Value := LStrings[i];
+          inc(i);
+          dec(nMax);
+        end;
+      end;
+    Finally
+      LAbstractMemZoneInfoList.Free;
+    End;
     Result := True;
   Finally
     LStrings.Free;

--- a/src/gui-classic/UFRMPascalCoinWalletConfig.pas
+++ b/src/gui-classic/UFRMPascalCoinWalletConfig.pas
@@ -94,6 +94,8 @@ type
     Property WalletKeys : TWalletKeys read FWalletKeys write SetWalletKeys;
   end;
 
+  {$I ../config.inc}
+
 implementation
 
 uses

--- a/src/gui-classic/UFRMWallet.pas
+++ b/src/gui-classic/UFRMWallet.pas
@@ -1373,7 +1373,7 @@ begin
   {$IFDEF USE_GNUGETTEXT}
   // use language from the params and retranslate if needed
   // might be better to move this a bit earlier in the formcreate routine
-  UseLanguage(FAppParams.ParamByName[CT_PARAM_UILanguage].GetAsString(GetCurrentLanguage));
+  UseLanguage(TSettings.AppParams.ParamByName[CT_PARAM_UILanguage].GetAsString(GetCurrentLanguage));
   RetranslateComponent(self);
   {$ENDIF}
   //


### PR DESCRIPTION
The method signature was changed in TAbstractMem.CheckConsistency to add a parameter TList<TAbstractMemZoneInfo>.

This caused the call in UPCRPCFileUtils to fail. This has been fixed, but no use is made of any data returned in the List.